### PR TITLE
Add an OpenSearch descriptor.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
           type="image/png" 
           href="/assets/pbl-logo-circle.png">
     <link href="/assets/pbl-logo.png" rel="apple-touch-icon" />
+    <link ref="search" type="application/opensearchdescription+xml" title="PBL Links" href="/opensearch.xml">
       <%= csrf_meta_tags %>
       <%= stylesheet_link_tag "application" %>
       <%= javascript_include_tag "application" %>

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+	<ShortName>PBL Links</ShortName>
+	<Description>Go to or search in PBL Links.</Description>
+	<Url type="text/html" template="http://testing.berkeley-pbl.com/{searchTerms}/go"/>
+	<Tags>pbl</Tags>
+	<Image height="900" width="900" type="image/png">http://testing.berkeley-pbl.com/assets/pbl-logo-circle.png</Image>
+</OpenSearchDescription>


### PR DESCRIPTION
This allows supported browsers to offer to add PBL Links as a
search engine. With this in place, Chrome users should be able
to search PBL Links quickly by typing "pbl<tab>" in the search bar,
and Firefox users will get the "Add PBL Links" option in the search
box to add it as a search engine.
